### PR TITLE
Clarify that enforce-and-report is intended

### DIFF
--- a/draft-stark-expect-ct.md
+++ b/draft-stark-expect-ct.md
@@ -155,7 +155,11 @@ unnecessary to send the same report to the same `report-uri` more than once.
 The OPTIONAL `enforce` directive is a valueless directive that, if present
 (i.e., it is "asserted"), signals to the UA that compliance to the CT policy
 should be enforced (rather than report-only) and that the UA should refuse
-future connections that violate its CT policy.
+future connections that violate its CT policy. When both the `enforce` directive
+and `report-uri` directive (as defined in {{reporturi-syntax}}) are present, the
+policy is referred to as an "enforce-and-report" policy, signalling to the UA
+both that compliance to the CT policy should be enforced and that violations
+should be reported.
 
 ### The max-age Directive
 


### PR DESCRIPTION
@equalsJeffH pointed out in https://lists.w3.org/Archives/Public/ietf-http-wg/2016OctDec/0549.html that it's not clear whether enforce-and-report configurations are intended to be allowed. This edit clarifies that such configurations are intended to be allowed and explicitly dubs them "enforce-and-report" as suggested.